### PR TITLE
Add /static/static directory + custom theme instructions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 Akkoma is a microblogging server software that can federate (= exchange messages with) other servers that support ActivityPub. What that means is that you can host a server for yourself or your friends and stay in control of your online identity, but still exchange messages with people on larger decentrilized and federated network. Akkoma will federate with all servers that implement ActivityPub, like Friendica, GNU Social, Hubzilla, Mastodon, Misskey, Pleroma, Peertube, or Pixelfed.
 
 
-**Shipped version:** 3.5.0~ynh3
+**Shipped version:** 3.6.0~ynh2
 
 **Demo:** https://otp.akkoma.dev
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,15 @@ Akkoma is a microblogging server software that can federate (= exchange messages
 
 This application come with the default frontend (Pleroma FE) and admin interface pre-installed and activated. There is also the Mangane front-end who is installed but not active. Note that you can choose other _alternative public interfaces_  (Brutaldon, Fedi FE...) or even provide a custom one.
 
-**Mastodon frontend:** if you installed the Mastodon FE package (from CLI or Admin interface) you can have access to an alternate user interface, similar the Mastodons or Glitch frontend. This frontend live alongside the default Pleroma FE: to access just add `/web` at the end of your instance domain (eg. `akkoma.domain.tld/web`). 
+**Mastodon frontend:** if you installed the Mastodon FE package (from CLI or Admin interface) you can have access to an alternate user interface, similar the Mastodons or Glitch frontend. This frontend live alongside the default Pleroma FE: to access just add `/web` at the end of your instance domain (eg. `akkoma.domain.tld/web`).
+
+### Custom theme
+
+You can eitheir create your custom theme or use [existing ones](https://docs.akkoma.dev/stable/configuration/howto_theming_your_instance/#get-an-existing-theme).
+To add custom themes, you will have to upload them to your instance dedicated folder (`/home/yunohost.app/akkoma/static/themes/` in Yunohost case), then to edit `/home/yunohost.app/akkoma/static/styles.json` to add a new entry referencing it. See the [official documentation](https://docs.akkoma.dev/stable/configuration/howto_theming_your_instance/#adding-the-custom-theme-to-the-instance) for more details.
+- Upload your custom theme, place it in `/home/yunohost.app/akkoma/static/themes/` (you could also directly edit the file from the command line and copy-paste the content).
+- Make sure the file access rights are approriate (only akkoma user can access them) `sudo chown -R akkoma:akkoma /home/yunohost.app/akkoma/static/themes/` (= own by akkoma) and `sudo chmod 750 /home/yunohost.app/akkoma/static/themes/` (=only akkoma can read and edit the file).
+- Then edit `/home/yunohost.app/akkoma/static/styles.json` for instance with `sudo su akkoma nano /home/yunohost.app/akkoma/static/styles.json`.
 
 ## Admin Tasks
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,24 @@ Akkoma is a microblogging server software that can federate (= exchange messages
 - **Login fails** for non YNH users if LDAP is activated (this is by default). See [#15](https://github.com/YunoHost-Apps/akkoma_ynh/issues/15) for more explanation.
 - No way to **change user password** from admin interface. May be related to previous bug. Work like charm from CLI.
 
+## Backups
+
+This application uses the [core-only feature of the backup](https://yunohost.org/en/backup/include_exclude_files#do-not-backup-large-amoun). **This means the app data directory** (`/home/yunohost.app/akkoma`, with subfolder `/static/`, which contains terms of service, custom emoji, custom themes, and `/uploads/` which contains the media attachements) **is not saved during backup**.
+Also to keep the integrity of the data and to have a better guarantee of the restoration it is recommended to stop Akkoma during the operation. Proceed as follows:
+- Stop Akkoma service with this command: `service akkoma stop`
+- Launch Akkoma backup with this command: `yunohost backup create --apps akkoma`
+- Backup Akkoma data directory with your specific strategy (could be with rsync, borg backup or just cp). The data is generally stored in `/home/yunohost.app/akkoma`.
+- Restart Akkoma service with this command: `service akkoma start`
+
+**If you want to create a Yunohost backup that contains also Akkoma data directory**, you should add `BACKUP_CORE_ONLY=0` at the start fo the command : `BACKUP_CORE_ONLY=0 yunohost backup create --app akkoma`.
+
+## Remove
+
+Due of the backup core only feature **the data directory in `/home/yunohost.app/akkoma` is not removed**. 
+If you want to delete the data folder `/home/yunohost.app/akkoma/` during removal of akkoma, you should add the `--purge` option. If you don't, it must be manually deleted to purge user data.
+**This is a necessary step for complete removal** - and possibly a fresh install.
+
+*NB: don't forget this mean those data are* not *backed up by default. See above.*
 
 ## Customization
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -48,7 +48,15 @@ Akkoma is a microblogging server software that can federate (= exchange messages
 
 This application come with the default frontend (Pleroma FE) and admin interface pre-installed and activated. There is also the Mangane front-end who is installed but not active. Note that you can choose other _alternative public interfaces_  (Brutaldon, Fedi FE...) or even provide a custom one.
 
-**Mastodon frontend:** if you installed the Mastodon FE package (from CLI or Admin interface) you can have access to an alternate user interface, similar the Mastodons or Glitch frontend. This frontend live alongside the default Pleroma FE: to access just add `/web` at the end of your instance domain (eg. `akkoma.domain.tld/web`). 
+**Mastodon frontend:** if you installed the Mastodon FE package (from CLI or Admin interface) you can have access to an alternate user interface, similar the Mastodons or Glitch frontend. This frontend live alongside the default Pleroma FE: to access just add `/web` at the end of your instance domain (eg. `akkoma.domain.tld/web`).
+
+### Custom theme
+
+You can eitheir create your custom theme or use [existing ones](https://docs.akkoma.dev/stable/configuration/howto_theming_your_instance/#get-an-existing-theme).
+To add custom themes, you will have to upload them to your instance dedicated folder (`/home/yunohost.app/akkoma/static/themes/` in Yunohost case), then to edit `/home/yunohost.app/akkoma/static/styles.json` to add a new entry referencing it. See the [official documentation](https://docs.akkoma.dev/stable/configuration/howto_theming_your_instance/#adding-the-custom-theme-to-the-instance) for more details.
+- Upload your custom theme, place it in `/home/yunohost.app/akkoma/static/themes/` (you could also directly edit the file from the command line and copy-paste the content).
+- Make sure the file access rights are approriate (only akkoma user can access them) `sudo chown -R akkoma:akkoma /home/yunohost.app/akkoma/static/themes/` (= own by akkoma) and `sudo chmod 750 /home/yunohost.app/akkoma/static/themes/` (=only akkoma can read and edit the file).
+- Then edit `/home/yunohost.app/akkoma/static/styles.json` for instance with `sudo su akkoma nano /home/yunohost.app/akkoma/static/styles.json`.
 
 ## Admin Tasks
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -19,7 +19,7 @@ Si vous n’avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) po
 Akkoma is a microblogging server software that can federate (= exchange messages with) other servers that support ActivityPub. What that means is that you can host a server for yourself or your friends and stay in control of your online identity, but still exchange messages with people on larger decentrilized and federated network. Akkoma will federate with all servers that implement ActivityPub, like Friendica, GNU Social, Hubzilla, Mastodon, Misskey, Pleroma, Peertube, or Pixelfed.
 
 
-**Version incluse :** 3.5.0~ynh3
+**Version incluse :** 3.6.0~ynh2
 
 **Démo :** https://otp.akkoma.dev
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -43,6 +43,24 @@ Akkoma is a microblogging server software that can federate (= exchange messages
 - **Login fails** for non YNH users if LDAP is activated (this is by default). See [#15](https://github.com/YunoHost-Apps/akkoma_ynh/issues/15) for more explanation.
 - No way to **change user password** from admin interface. May be related to previous bug. Work like charm from CLI.
 
+## Backups
+
+This application uses the [core-only feature of the backup](https://yunohost.org/en/backup/include_exclude_files#do-not-backup-large-amoun). **This means the app data directory** (`/home/yunohost.app/akkoma`, with subfolder `/static/`, which contains terms of service, custom emoji, custom themes, and `/uploads/` which contains the media attachements) **is not saved during backup**.
+Also to keep the integrity of the data and to have a better guarantee of the restoration it is recommended to stop Akkoma during the operation. Proceed as follows:
+- Stop Akkoma service with this command: `service akkoma stop`
+- Launch Akkoma backup with this command: `yunohost backup create --apps akkoma`
+- Backup Akkoma data directory with your specific strategy (could be with rsync, borg backup or just cp). The data is generally stored in `/home/yunohost.app/akkoma`.
+- Restart Akkoma service with this command: `service akkoma start`
+
+**If you want to create a Yunohost backup that contains also Akkoma data directory**, you should add `BACKUP_CORE_ONLY=0` at the start fo the command : `BACKUP_CORE_ONLY=0 yunohost backup create --app akkoma`.
+
+## Remove
+
+Due of the backup core only feature **the data directory in `/home/yunohost.app/akkoma` is not removed**. 
+If you want to delete the data folder `/home/yunohost.app/akkoma/` during removal of akkoma, you should add the `--purge` option. If you don't, it must be manually deleted to purge user data.
+**This is a necessary step for complete removal** - and possibly a fresh install.
+
+*NB: don't forget this mean those data are* not *backed up by default. See above.*
 
 ## Customization
 

--- a/conf/styles.json
+++ b/conf/styles.json
@@ -1,0 +1,8 @@
+{
+  "pleroma-dark": [ "Pleroma Dark", "#121a24", "#182230", "#b9b9ba", "#d8a070", "#d31014", "#0fa00f", "#0095ff", "#ffa500" ],
+  "pleroma-light": [ "Pleroma Light", "#f2f4f6", "#dbe0e8", "#304055", "#f86f0f", "#d31014", "#0fa00f", "#0095ff", "#ffa500" ],
+  "classic-dark": [ "Classic Dark", "#161c20", "#282e32", "#b9b9b9", "#baaa9c", "#d31014", "#0fa00f", "#0095ff", "#ffa500" ],
+  "bird": [ "Bird", "#f8fafd", "#e6ecf0", "#14171a", "#0084b8", "#e0245e", "#17bf63", "#1b95e0", "#fab81e"],
+  "ir-black": [ "Ir Black", "#000000", "#242422", "#b5b3aa", "#ff6c60", "#FF6C60", "#A8FF60", "#96CBFE", "#FFFFB6" ],
+  "monokai": [ "Monokai", "#272822", "#383830", "#f8f8f2", "#f92672", "#F92672", "#a6e22e", "#66d9ef", "#f4bf75" ],
+}

--- a/doc/DISCLAIMER.md
+++ b/doc/DISCLAIMER.md
@@ -17,7 +17,15 @@
 
 This application come with the default frontend (Pleroma FE) and admin interface pre-installed and activated. There is also the Mangane front-end who is installed but not active. Note that you can choose other _alternative public interfaces_  (Brutaldon, Fedi FE...) or even provide a custom one.
 
-**Mastodon frontend:** if you installed the Mastodon FE package (from CLI or Admin interface) you can have access to an alternate user interface, similar the Mastodons or Glitch frontend. This frontend live alongside the default Pleroma FE: to access just add `/web` at the end of your instance domain (eg. `akkoma.domain.tld/web`). 
+**Mastodon frontend:** if you installed the Mastodon FE package (from CLI or Admin interface) you can have access to an alternate user interface, similar the Mastodons or Glitch frontend. This frontend live alongside the default Pleroma FE: to access just add `/web` at the end of your instance domain (eg. `akkoma.domain.tld/web`).
+
+### Custom theme
+
+You can eitheir create your custom theme or use [existing ones](https://docs.akkoma.dev/stable/configuration/howto_theming_your_instance/#get-an-existing-theme).
+To add custom themes, you will have to upload them to your instance dedicated folder (`/home/yunohost.app/akkoma/static/themes/` in Yunohost case), then to edit `/home/yunohost.app/akkoma/static/styles.json` to add a new entry referencing it. See the [official documentation](https://docs.akkoma.dev/stable/configuration/howto_theming_your_instance/#adding-the-custom-theme-to-the-instance) for more details.
+- Upload your custom theme, place it in `/home/yunohost.app/akkoma/static/themes/` (you could also directly edit the file from the command line and copy-paste the content).
+- Make sure the file access rights are approriate (only akkoma user can access them) `sudo chown -R akkoma:akkoma /home/yunohost.app/akkoma/static/themes/` (= own by akkoma) and `sudo chmod 750 /home/yunohost.app/akkoma/static/themes/` (=only akkoma can read and edit the file).
+- Then edit `/home/yunohost.app/akkoma/static/styles.json` for instance with `sudo su akkoma nano /home/yunohost.app/akkoma/static/styles.json`.
 
 ## Admin Tasks
 

--- a/doc/DISCLAIMER.md
+++ b/doc/DISCLAIMER.md
@@ -12,6 +12,24 @@
 - **Login fails** for non YNH users if LDAP is activated (this is by default). See [#15](https://github.com/YunoHost-Apps/akkoma_ynh/issues/15) for more explanation.
 - No way to **change user password** from admin interface. May be related to previous bug. Work like charm from CLI.
 
+## Backups
+
+This application uses the [core-only feature of the backup](https://yunohost.org/en/backup/include_exclude_files#do-not-backup-large-amoun). **This means the app data directory** (`/home/yunohost.app/akkoma`, with subfolder `/static/`, which contains terms of service, custom emoji, custom themes, and `/uploads/` which contains the media attachements) **is not saved during backup**.
+Also to keep the integrity of the data and to have a better guarantee of the restoration it is recommended to stop Akkoma during the operation. Proceed as follows:
+- Stop Akkoma service with this command: `service akkoma stop`
+- Launch Akkoma backup with this command: `yunohost backup create --apps akkoma`
+- Backup Akkoma data directory with your specific strategy (could be with rsync, borg backup or just cp). The data is generally stored in `/home/yunohost.app/akkoma`.
+- Restart Akkoma service with this command: `service akkoma start`
+
+**If you want to create a Yunohost backup that contains also Akkoma data directory**, you should add `BACKUP_CORE_ONLY=0` at the start fo the command : `BACKUP_CORE_ONLY=0 yunohost backup create --app akkoma`.
+
+## Remove
+
+Due of the backup core only feature **the data directory in `/home/yunohost.app/akkoma` is not removed**. 
+If you want to delete the data folder `/home/yunohost.app/akkoma/` during removal of akkoma, you should add the `--purge` option. If you don't, it must be manually deleted to purge user data.
+**This is a necessary step for complete removal** - and possibly a fresh install.
+
+*NB: don't forget this mean those data are* not *backed up by default. See above.*
 
 ## Customization
 

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Federated social networking server built on ActivityPub open protocol",
         "fr": "Serveur de réseautage social fédéré basé sur le protocole ouvert ActivityPub"
     },
-    "version": "3.5.0~ynh3",
+    "version": "3.6.0~ynh2",
     "url": "https://akkoma.social/",
     "upstream": {
         "license": "AGPL-3.0-only",

--- a/scripts/backup
+++ b/scripts/backup
@@ -48,6 +48,7 @@ ynh_backup --src_path="$final_path"
 # BACKUP THE DATA DIR
 #=================================================
 
+# When using BACKUP_CORE_ONLY (default), this folder will not be saved. This saves a lot of space and time, in particular during upgrades.
 ynh_backup --src_path="$datadir" --is_big
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -154,6 +154,7 @@ mkdir -p "$datadir/uploads/"
 mkdir -p "$datadir/static/"
 mkdir -p "$datadir/static/emoji/"
 mkdir -p "$datadir/static/static/themes"
+mv ../conf/styles.json "$datadir/static/styles.json"
 
 chmod 750 "$datadir"
 chmod -R o-rwx "$datadir"

--- a/scripts/install
+++ b/scripts/install
@@ -153,6 +153,7 @@ mkdir -p $datadir
 mkdir -p "$datadir/uploads/"
 mkdir -p "$datadir/static/"
 mkdir -p "$datadir/static/emoji/"
+mkdir -p "$datadir/static/static/themes"
 
 chmod 750 "$datadir"
 chmod -R o-rwx "$datadir"

--- a/scripts/remove
+++ b/scripts/remove
@@ -71,8 +71,10 @@ ynh_secure_remove --file="$final_path"
 # Remove the data directory if --purge option is used
 if [ "${YNH_APP_PURGE:-0}" -eq 1 ]
 then
-	ynh_script_progression --message="Removing app data directory..." --weight=1
+	ynh_script_progression --message="Purge option was selected. Removing app data directory..." --weight=1
 	ynh_secure_remove --file="$datadir"
+else
+	ynh_script_progression --message="Purge option was not selected. App data directory is not removed. That is good if you want to restore a backup. For fresh install, you should remove it first." --weight=1
 fi
 
 #=================================================


### PR DESCRIPTION
- The `/static/static` is missing, hence admins can't easily add custom theme, emojis or terms of service.
So we create it by default.
Fix https://github.com/YunoHost-Apps/akkoma_ynh/issues/18 

- Static (data) directory is not backed up (due to Backup Core Only). So we add instructions about it.
Fix #16