### PR TITLE
Version 2023.04  (still OTP 25.2.2) + fix frontend upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 Akkoma is a microblogging server software that can federate (= exchange messages with) other servers that support ActivityPub. What that means is that you can host a server for yourself or your friends and stay in control of your online identity, but still exchange messages with people on larger decentrilized and federated network. Akkoma will federate with all servers that implement ActivityPub, like Friendica, GNU Social, Hubzilla, Mastodon, Misskey, Pleroma, Peertube, or Pixelfed.
 
 
-**Shipped version:** 3.7.1~ynh1
+**Shipped version:** 3.7.1~ynh2
 
 **Demo:** https://otp.akkoma.dev
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -19,7 +19,7 @@ Si vous n’avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) po
 Akkoma is a microblogging server software that can federate (= exchange messages with) other servers that support ActivityPub. What that means is that you can host a server for yourself or your friends and stay in control of your online identity, but still exchange messages with people on larger decentrilized and federated network. Akkoma will federate with all servers that implement ActivityPub, like Friendica, GNU Social, Hubzilla, Mastodon, Misskey, Pleroma, Peertube, or Pixelfed.
 
 
-**Version incluse :** 3.7.1~ynh1
+**Version incluse :** 3.7.1~ynh2
 
 **Démo :** https://otp.akkoma.dev
 

--- a/conf/amd64.src
+++ b/conf/amd64.src
@@ -1,5 +1,5 @@
 SOURCE_URL=https://akkoma-updates.s3-website.fr-par.scw.cloud/stable/akkoma-amd64.zip
-SOURCE_SUM=ea4f31b88b4de78f4c5bfb72e6969927b509012dc25b42d064c8dbc3be2cacbf
+SOURCE_SUM=959fdfcced0783f73d0038e1e7fd5c1089f2400ccbb7375cc6fa04fca4600ee8
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=zip
 SOURCE_IN_SUBDIR=true

--- a/conf/frontend_switcher.exs
+++ b/conf/frontend_switcher.exs
@@ -1,3 +1,5 @@
-config :pleroma, :frontends, :pickable 
-  "pleroma-fe/stable",
-  "mangane/dist"
+config :pleroma, :frontends,
+  pickable: [
+    "pleroma-fe/stable",
+    "mangane/dist"
+  ]

--- a/conf/frontend_switcher.exs
+++ b/conf/frontend_switcher.exs
@@ -1,0 +1,3 @@
+config :pleroma, :frontends, :pickable 
+  "pleroma-fe/stable",
+  "mangane/dist"

--- a/conf/static_and_modules_dir.exs
+++ b/conf/static_and_modules_dir.exs
@@ -1,5 +1,5 @@
 # Static directory needs to be adapted for Yunohost specific setup
-config : pleroma, :instance, static_dir: "/home/yunohost.app/akkoma/static"
-config : pleroma, Pleroma.Uploaders.Local, uploads: "/home/yunohost.app/akkoma/uploads"
+config :pleroma, :instance, static_dir: "/home/yunohost.app/akkoma/static"
+config :pleroma, Pleroma.Uploaders.Local, uploads: "/home/yunohost.app/akkoma/uploads"
 # Module directory needs to be adapted for Yunohost specific setup
 config :pleroma, :modules, runtime_dir: "/home/yunohost.app/akkoma/modules"

--- a/conf/static_and_modules_dir.exs
+++ b/conf/static_and_modules_dir.exs
@@ -1,0 +1,5 @@
+# Static directory needs to be adapted for Yunohost specific setup
+config : pleroma, :instance, static_dir: "/home/yunohost.app/akkoma/static"
+config : pleroma, Pleroma.Uploaders.Local, uploads: "/home/yunohost.app/akkoma/uploads"
+# Module directory needs to be adapted for Yunohost specific setup
+config :pleroma, :modules, runtime_dir: "/home/yunohost.app/akkoma/modules"

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Federated social networking server built on ActivityPub open protocol",
         "fr": "Serveur de réseautage social fédéré basé sur le protocole ouvert ActivityPub"
     },
-    "version": "3.7.1~ynh1",
+    "version": "3.7.1~ynh2",
     "url": "https://akkoma.social/",
     "upstream": {
         "license": "AGPL-3.0-only",

--- a/scripts/install
+++ b/scripts/install
@@ -213,6 +213,14 @@ popd
 
 cat "../conf/ldap.exs" >> "$config"
 
+# Configure proper static & module directories
+cat "../conf/static_and_modules_dir.exs" >>  "$config"
+
+# Setup frontend switcher
+# Available here : domain.tld/akkoma/frontend
+# It is probably needed to do it before changing "configurable_from_database" as the config file will no longer be used ?
+cat "../conf/frontend_switcher.exs" >> "$config"
+
 ynh_replace_string --match_string="config :akkoma, configurable_from_database: false" --replace_string="config :akkoma, configurable_from_database: true" --target_file="$config"
 registration_bool_value=`(($registration)) && echo "true" || echo "false"`
 ynh_replace_string --match_string="registrations_open: true" --replace_string="registrations_open: $registration_bool_value" --target_file="$config"
@@ -309,10 +317,6 @@ ynh_exec_warn_less ynh_exec_as $app -s $SHELL -lc "$final_path/live/bin/pleroma_
 ynh_script_progression --message="Installing Mangane FrontEnd..." --weight=1
 ynh_exec_warn_less ynh_exec_as $app -s $SHELL -lc "$final_path/live/bin/pleroma_ctl frontend install mangane --ref dist --build-url https://github.com/BDX-town/Mangane/releases/latest/download/static.zip"
 # Not activated, users need to change the "primary" frontend in the admin UI (use 'mangane' and 'dist').
-
-# setup frontend switcher
-# available here : domain.tld/akkoma/frontend
-cat "../conf/frontend_switcher.exs" >> "$config"
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/install
+++ b/scripts/install
@@ -310,6 +310,10 @@ ynh_script_progression --message="Installing Mangane FrontEnd..." --weight=1
 ynh_exec_warn_less ynh_exec_as $app -s $SHELL -lc "$final_path/live/bin/pleroma_ctl frontend install mangane --ref dist --build-url https://github.com/BDX-town/Mangane/releases/latest/download/static.zip"
 # Not activated, users need to change the "primary" frontend in the admin UI (use 'mangane' and 'dist').
 
+# setup frontend switcher
+# available here : domain.tld/akkoma/frontend
+cat "../conf/frontend_switcher.exs" >> "$config"
+
 #=================================================
 # END OF SCRIPT
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -293,6 +293,27 @@ ynh_script_progression --message="Starting a systemd service..." --weight=1
 ynh_systemd_action --service_name=$app --action="start" --log_path=systemd --line_match="Access akkoma.Web.Endpoint"
 
 #=================================================
+# INSTALL BASIC FRONTENDS (Upgrade them)
+#=================================================
+#### Fontends need Akkoma to be already running, so they are installed at the very end
+
+# Pleroma Front-End
+ynh_script_progression --message="Upgrading Pleroma FrontEnd..." --weight=1
+ynh_exec_warn_less ynh_exec_as $app -s $SHELL -lc "$final_path/live/bin/pleroma_ctl frontend install pleroma-fe --ref stable"
+
+# Admin Front-End
+ynh_script_progression --message="Upgrading Admin FrontEnd..." --weight=1
+ynh_exec_warn_less ynh_exec_as $app -s $SHELL -lc "$final_path/live/bin/pleroma_ctl frontend install admin-fe --ref stable"
+
+#=================================================
+# INSTALL MANGANE FRONTEND (Upgrade it)
+#=================================================
+# Mangane alternative Front-End will be built in, ready to enable
+ynh_script_progression --message="Upgrading Mangane FrontEnd..." --weight=1
+ynh_exec_warn_less ynh_exec_as $app -s $SHELL -lc "$final_path/live/bin/pleroma_ctl frontend install mangane --ref dist --build-url https://github.com/BDX-town/Mangane/releases/latest/download/static.zip"
+# Not activated, users need to change the "primary" frontend in the admin UI (use 'mangane' and 'dist').
+
+#=================================================
 # RELOAD NGINX
 #=================================================
 ynh_script_progression --message="Reloading NGINX web server..." --weight=1

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -196,6 +196,16 @@ if ynh_version_gt "2.4.4~ynh2" "${previous_version}"; then
 	ynh_replace_string --match_string='registrations_open: true' --replace_string="registrations_open: $registration_bool_value" --target_file="$config"
 fi
 
+# Add frontend switcher if needed
+
+if grep -q ':pleroma, :frontends, :pickable' $config # This is not resilient to any spacing change, to be refined
+then
+    ynh_script_progression --message="Frontend switcher config already existing, nothing to do about it." --weight=0
+else
+    ynh_script_progression --message="Adding frontend switcher config." --weight=0
+    cat "../conf/frontend_switcher.exs" >> "$config"
+fi
+
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE
 #=================================================


### PR DESCRIPTION
https://meta.akkoma.dev/t/akkoma-stable-2023-04-switchable-front-timeline-visibility-hehe/429


[Changelog](https://akkoma.dev/AkkomaGang/akkoma/src/branch/develop/CHANGELOG.md):
> - Nodeinfo keys for unauthenticated timeline visibility
> - Option to disable federated timeline
> - Option to make the bubble timeline publicly accessible
> - Ability to swap between installed standard frontends
>   -     mastodon frontends are still not counted as standard frontends due to the complexity in serving them correctly.

---

In addition, frontends need to be upgraded (re-run install command) regularly, for instance after an Akkoma upgrade.