### PR TITLE
2023.08 / 3.10.3 / OTP 25.3.2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 Akkoma is a microblogging server software that can federate (= exchange messages with) other servers that support ActivityPub. What that means is that you can host a server for yourself or your friends and stay in control of your online identity, but still exchange messages with people on larger decentrilized and federated network. Akkoma will federate with all servers that implement ActivityPub, like Friendica, GNU Social, Hubzilla, Mastodon, Misskey, Pleroma, Peertube, or Pixelfed.
 
 
-**Shipped version:** 3.9.3~ynh4
+**Shipped version:** 3.10.3~ynh1
 
 **Demo:** https://otp.akkoma.dev
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -19,7 +19,7 @@ Si vous n’avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) po
 Akkoma is a microblogging server software that can federate (= exchange messages with) other servers that support ActivityPub. What that means is that you can host a server for yourself or your friends and stay in control of your online identity, but still exchange messages with people on larger decentrilized and federated network. Akkoma will federate with all servers that implement ActivityPub, like Friendica, GNU Social, Hubzilla, Mastodon, Misskey, Pleroma, Peertube, or Pixelfed.
 
 
-**Version incluse :** 3.9.3~ynh4
+**Version incluse :** 3.10.3~ynh1
 
 **Démo :** https://otp.akkoma.dev
 

--- a/conf/amd64.src
+++ b/conf/amd64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://akkoma-updates.s3-website.fr-par.scw.cloud/stable/akkoma-amd64.zip
-SOURCE_SUM=53acaecf82283d724c7c64b403b8130d22cbe050f6c224f55f73a158da2c52fe
+SOURCE_URL=https://akkoma-updates.s3-website.fr-par.scw.cloud/stable/akkoma-amd64-debian-bullseye.zip
+SOURCE_SUM=20bc9b2c2d07203526b798cc0941768f5f40d1598e501cc426d10f45c434f3b5
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=zip
 SOURCE_IN_SUBDIR=true

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Federated social networking server built on ActivityPub open protocol",
         "fr": "Serveur de réseautage social fédéré basé sur le protocole ouvert ActivityPub"
     },
-    "version": "3.9.3~ynh4",
+    "version": "3.10.3~ynh1",
     "url": "https://akkoma.social/",
     "upstream": {
         "license": "AGPL-3.0-only",


### PR DESCRIPTION
New features and changelog : https://meta.akkoma.dev/t/akkoma-stable-2023-08-secure-arms-are-bookworms/545

This includes a security hotfix of high priority, to be merged as soon as CI is happy.


Note that this version would have broken Debian 11 compatibility for OTP versions (in the future, if we still need it we will have to release our own OTP build), but this time Akkoma dev was kind enough to provide a special OTP build for us. Hence the changed source link.
